### PR TITLE
implement gatekeeper win-state and relic collection system

### DIFF
--- a/headers/Player.h
+++ b/headers/Player.h
@@ -20,6 +20,12 @@ public:
 	WINDOW *statsWindow;
 	int showStats;
 	int terrain_room_x, terrain_room_y;
+
+	// Sınıfın public: kısmına şunları ekle:
+	int relicCount;
+	void addRelic();
+	int getRelicCount() const;
+
 private:
 	//int heigth, width = 3;
 };

--- a/headers/terrain/Terrain.h
+++ b/headers/terrain/Terrain.h
@@ -10,9 +10,18 @@ class Terrain {
 		virtual ~Terrain();
 
 		Room room[3][3];
+
+		GateKeeper* gateKeeper;
+		int gatekeeperRoomX;
+		int gatekeeperRoomY;
+
+		void positionGatekeeper();
+		void removeGatekeeper();
+
 	protected:
 
 	private:
+		
 };
 
 #endif // TERRAIN_H

--- a/headers/terrain/Terrain.h
+++ b/headers/terrain/Terrain.h
@@ -17,7 +17,6 @@ class Terrain {
 
 		void positionGatekeeper();
 		void removeGatekeeper();
-
 	protected:
 
 	private:

--- a/retroBattle.cpp
+++ b/retroBattle.cpp
@@ -139,26 +139,6 @@ int main() {
 		}
 		*/
 
-		//GateKeeper Collision Detection 
-		GateKeeper *gatekeeper = terrain.room[player->terrain_room_x][player->terrain_room_y].getGatekeeper();
-		if (gatekeeper != nullptr) {
-			if (circleCollisionDetection(terrain.room[player->terrain_room_x][player->terrain_room_y].entity_manager->getPlayer(), { gatekeeper }).size() > 0) {
-				int midY = _rows / 2;
-				int midX = _cols / 2;
-
-				mvprintw(midY, midX - 4, "YOU WON!");
-				mvprintw(midY + 1, midX - 15, "Press any key to restart...");
-				refresh();
-
-				nodelay(stdscr, false);
-				getch();
-				nodelay(stdscr, true);
-
-				terrain.room[player->terrain_room_x][player->terrain_room_y].entity_manager->getPlayer()->setPosition(Vec2d(30.0, 30.0));
-				gatekeeper->setPosition(Vec2d(gatekeeper->rng->getRandomNumber(5, _cols - 5), gatekeeper->rng->getRandomNumber(5, _rows - 5)));
-			    continue;
-			}
-		}
 		
 		// Relics Collision Detection
 		for (Item*& r : relics) {
@@ -178,6 +158,7 @@ int main() {
 				nodelay(stdscr, true);
 
 				player->setAttack(player->getAttack() + 20);
+				player->addRelic();
 
 				delete r;
 				r = nullptr;
@@ -185,6 +166,62 @@ int main() {
 				break;
 			}
 		}
+
+		//Gatekeeper win state
+		if (terrain.gateKeeper != nullptr &&
+			player->terrain_room_x == terrain.gatekeeperRoomX &&
+			player->terrain_room_y == terrain.gatekeeperRoomY) {
+
+			float distanceX = calculateAbsoluteDistance(player->getPosition().x, terrain.gateKeeper->getPosition().x);
+			float distanceY = calculateAbsoluteDistance(player->getPosition().y, terrain.gateKeeper->getPosition().y);
+
+		
+			if (distanceX < 4.0f && distanceY < 4.0f) {
+				clearScreen();
+				if (player->getRelicCount() >= 3) {
+				
+					mvprintw(15, 45, "GATEKEEPER: Access granted. You have proven yourself!");
+					mvprintw(17, 45, "CONGRATULATIONS, YOU HAVE WON THE GAME!");
+					mvprintw(20, 45, "Do you want to play again? [y/N]");
+					refresh();
+
+					nodelay(stdscr, false);
+					char input = getch();
+					if (input == 'y' || input == 'Y') {
+						
+						player->relicCount = 0;
+						terrain.removeGatekeeper();
+						terrain.positionGatekeeper();
+						for (Item*& r : relics) {
+							delete r;   
+							r = nullptr;
+						}
+
+						relics[0] = new Relic(Vec2d(10, 10), 5, RelicType::AttackBoost);
+						relics[1] = new Relic(Vec2d(20, 20), 5, RelicType::SpeedBoost);
+						relics[2] = new Relic(Vec2d(30, 30), 5, RelicType::HealthBoost);
+					}
+
+					else {
+					
+						RUNNING = 0;
+					}
+					nodelay(stdscr, true);
+				}
+				else {
+				
+					mvprintw(15, 40, "GATEKEEPER: No, you don't have enough relics.");
+					mvprintw(16, 40, "Bring me first enough relics to win! (Current: %d / 3)", player->getRelicCount());
+					refresh();
+
+					nodelay(stdscr, false);
+					getch();
+					nodelay(stdscr, true);
+				}
+				clearScreen();
+			}
+		}
+	
 
 		// BattleManager Collision Detection 
 		auto collider = circleCollisionDetection(terrain.room[player->terrain_room_x][player->terrain_room_y].entity_manager->getPlayer(), terrain.room[player->terrain_room_x][player->terrain_room_y].entity_manager->getEnemies());

--- a/retroBattle.cpp
+++ b/retroBattle.cpp
@@ -189,6 +189,7 @@ int main() {
 					if (input == 'y' || input == 'Y') {
 						
 						player->relicCount = 0;
+						player->setAttack(10);
 						terrain.removeGatekeeper();
 						terrain.positionGatekeeper();
 						for (Item*& r : relics) {
@@ -202,7 +203,6 @@ int main() {
 					}
 
 					else {
-					
 						RUNNING = 0;
 					}
 					nodelay(stdscr, true);

--- a/retroBattle.cpp
+++ b/retroBattle.cpp
@@ -138,7 +138,6 @@ int main() {
 			mvprintw(0, 40, "Collision!!");
 		}
 		*/
-
 		
 		// Relics Collision Detection
 		for (Item*& r : relics) {
@@ -209,9 +208,9 @@ int main() {
 					nodelay(stdscr, true);
 				}
 				else {
-				
 					mvprintw(15, 40, "GATEKEEPER: No, you don't have enough relics.");
 					mvprintw(16, 40, "Bring me first enough relics to win! (Current: %d / 3)", player->getRelicCount());
+					player->setPosition(player->getPosition() - (player->getDirection() * 2));
 					refresh();
 
 					nodelay(stdscr, false);

--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -5,6 +5,7 @@ Player::Player() : Entity() {
 	statsWindow = nullptr;
 	terrain_room_x = 1;
 	terrain_room_y = 1;
+	relicCount = 0;
 }
 
 Player::Player(int id, const int width, const int height, Vec2d position) : Entity(id, width, height, position) {
@@ -12,6 +13,7 @@ Player::Player(int id, const int width, const int height, Vec2d position) : Enti
 	statsWindow = nullptr;
 	terrain_room_x = 1;
 	terrain_room_y = 1;
+	relicCount = 0;
 }
 
 Player::~Player() {
@@ -31,12 +33,14 @@ void Player::drawSelf() const {
 void Player::displayStats() {
 	if (showStats) {
 		if (statsWindow == nullptr) {
-			statsWindow = subwin(stdscr, 4, 45, 1, 110);
+			statsWindow = subwin(stdscr, 5, 45, 1, 110);
 		}
 		wclear(statsWindow);
 		box(statsWindow, 0, 0);
 		mvwprintw(statsWindow, 1, 1, "x: %f    y: %f", getPosition().x, getPosition().y);
 		mvwprintw(statsWindow, 2, 1, "Direction X: %.2f    Direction Y: %.2f", getDirection().x, getDirection().y);
+
+		mvwprintw(statsWindow, 3, 1, "Relics: %d / 5", relicCount);
 	}
 }
 
@@ -91,6 +95,14 @@ void Player::roomCheck(Terrain *terrain, Vec2d &pos) {
 
 EntityTypes::Type Player::getType() const {
 	return EntityTypes::Type::Player;
+}
+
+void Player::addRelic() {
+	relicCount++;
+}
+
+int Player::getRelicCount() const {
+	return relicCount;
 }
 
 /*

--- a/source/terrain/Terrain.cpp
+++ b/source/terrain/Terrain.cpp
@@ -14,12 +14,12 @@ Terrain::Terrain() {
 	getmaxyx(stdscr, _rows, _cols);
 
 	// ########################  Main Room [1][1] ###############################
-	MersenneTwister tempRng;
-	int randX = tempRng.getRandomNumber(5, _cols - 5);
-	int randY = tempRng.getRandomNumber(5, _rows - 5);
-	GateKeeper *gatekeeper = new GateKeeper(7, 5, 5, Vec2d(randX, randY));
+	//MersenneTwister tempRng;
+	//int randX = tempRng.getRandomNumber(5, _cols - 5);
+	//int randY = tempRng.getRandomNumber(5, _rows - 5);
+	
 
-	Player* player = new Player(1, 5, 5, Vec2d(145.0, 30.0));
+	Player* player = new Player(1, 5, 5, Vec2d(75.0, 30.0));
 	Enemy* enemy1 = new Enemy(2, 5, 5, Vec2d(60.0, 20.0));
 	Enemy* enemy2 = new Enemy(3, 5, 5, Vec2d(40.0, 30.0));
 	Enemy* enemy3 = new Enemy(4, 5, 5, Vec2d(45.0, 15.0));
@@ -37,7 +37,7 @@ Terrain::Terrain() {
 	enemy6->movement = new ChaseMovement(player, enemy6);
 	slySnake->movement = new GuardingMovement(Vec2d(30.0, 25.0), Vec2d(60.0, 25.0));
 
-	std::vector<Entity*> entities = { enemy1, enemy2, enemy3, enemy4, enemy5, enemy6, gatekeeper, player, slySnake };
+	std::vector<Entity*> entities = { enemy1, enemy2, enemy3, enemy4, enemy5, enemy6, player, slySnake };
 	room[1][1] = Room(_cols, _rows);
 	room[1][1].entity_manager = new EntityManager(entities);
 
@@ -135,6 +135,42 @@ Terrain::Terrain() {
 	roomEntities_2_2[1]->movement = new ChaseMovement(player, roomEntities_2_2[1]);
 	room[2][2] = Room(_cols, _rows);
 	room[2][2].entity_manager = new EntityManager(roomEntities_2_2);
+
+	gateKeeper = nullptr;
+	positionGatekeeper();
 }
+
+	void Terrain::positionGatekeeper() {
+	MersenneTwister rng;
+	int x = rng.getRandomNumber(0, 2);
+	int y = rng.getRandomNumber(0, 2);
+
+	int _rows = 0, _cols = 0;
+	getmaxyx(stdscr, _rows, _cols);
+	int rastgeleX = rng.getRandomNumber(5, _cols - 5);
+	int rastgeleY = rng.getRandomNumber(5, _rows - 5);
+
+	gateKeeper = new GateKeeper(7, 5, 5, Vec2d(rastgeleX, rastgeleY));
+	gatekeeperRoomX = x;
+	gatekeeperRoomY = y;
+
+	room[x][y].entity_manager->entities.push_back(gateKeeper);
+}
+
+	void Terrain::removeGatekeeper() {
+		if (gateKeeper == nullptr) return;  
+
+		auto& entityList = room[gatekeeperRoomX][gatekeeperRoomY].entity_manager->entities;
+
+		for (int i = 0; i < entityList.size(); i++) {
+			if (entityList[i] == gateKeeper) {
+				entityList.erase(entityList.begin() + i);
+				break;
+			}
+		}
+
+		delete gateKeeper;
+		gateKeeper = nullptr;
+	}
 
 Terrain::~Terrain() {}

--- a/source/terrain/Terrain.cpp
+++ b/source/terrain/Terrain.cpp
@@ -140,7 +140,7 @@ Terrain::Terrain() {
 	positionGatekeeper();
 }
 
-	void Terrain::positionGatekeeper() {
+void Terrain::positionGatekeeper() {
 	MersenneTwister rng;
 	int x = rng.getRandomNumber(0, 2);
 	int y = rng.getRandomNumber(0, 2);
@@ -157,20 +157,20 @@ Terrain::Terrain() {
 	room[x][y].entity_manager->entities.push_back(gateKeeper);
 }
 
-	void Terrain::removeGatekeeper() {
-		if (gateKeeper == nullptr) return;  
+void Terrain::removeGatekeeper() {
+	if (gateKeeper == nullptr) return;  
 
-		auto& entityList = room[gatekeeperRoomX][gatekeeperRoomY].entity_manager->entities;
+	auto& entityList = room[gatekeeperRoomX][gatekeeperRoomY].entity_manager->entities;
 
-		for (int i = 0; i < entityList.size(); i++) {
-			if (entityList[i] == gateKeeper) {
-				entityList.erase(entityList.begin() + i);
-				break;
-			}
+	for (int i = 0; i < entityList.size(); i++) {
+		if (entityList[i] == gateKeeper) {
+			entityList.erase(entityList.begin() + i);
+			break;
 		}
-
-		delete gateKeeper;
-		gateKeeper = nullptr;
 	}
+
+	delete gateKeeper;
+	gateKeeper = nullptr;
+}
 
 Terrain::~Terrain() {}

--- a/source/terrain/Terrain.cpp
+++ b/source/terrain/Terrain.cpp
@@ -140,6 +140,8 @@ Terrain::Terrain() {
 	positionGatekeeper();
 }
 
+Terrain::~Terrain() {}
+
 void Terrain::positionGatekeeper() {
 	MersenneTwister rng;
 	int x = rng.getRandomNumber(0, 2);
@@ -158,7 +160,7 @@ void Terrain::positionGatekeeper() {
 }
 
 void Terrain::removeGatekeeper() {
-	if (gateKeeper == nullptr) return;  
+	if (gateKeeper == nullptr) return;
 
 	auto& entityList = room[gatekeeperRoomX][gatekeeperRoomY].entity_manager->entities;
 
@@ -172,5 +174,3 @@ void Terrain::removeGatekeeper() {
 	delete gateKeeper;
 	gateKeeper = nullptr;
 }
-
-Terrain::~Terrain() {}


### PR DESCRIPTION
- Der Gatekeeper erscheint nun in einem zufälligen Raum. Dies erhöht die Wiederspielbarkeit.
- Der Spieler muss nun 3 Relikte sammeln, um den Gatekeeper freizuschalten.Wenn der Spieler 3 Relikte hat, kann er den Gatekeeper treffen und das Spiel gewinnen.
- Nach dem Sieg kann der Spieler das Spiel neu starten. Alles wird sicher zurückgesetzt (Relikte, Gatekeeper-Position, Speicher).
Zeitaufwand: 14 Stunde